### PR TITLE
[WIP]: Improve compare css values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/darlanmendonca/chai-style.svg?branch=master)](https://travis-ci.org/darlanmendonca/chai-style)
-[![Coverage Status](https://coveralls.io/repos/github/darlanmendonca/chai-style/badge.svg?branch=master)](https://coveralls.io/github/darlanmendonca/chai-style?branch=master)
+<!-- [![Coverage Status](https://coveralls.io/repos/github/darlanmendonca/chai-style/badge.svg?branch=master)](https://coveralls.io/github/darlanmendonca/chai-style?branch=master) -->
 
 # chai-style
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "eslint-config-mn-component": "^1.1.0",
     "istanbul": "1.0.0-alpha.2",
     "jsdom": "^10.1.0",
-    "karma": "^1.6.0",
+    "karma": "^1.7.0",
     "karma-browserify": "^5.1.1",
     "karma-browserstack-launcher": "^1.2.0",
     "karma-chrome-launcher": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -30,9 +30,6 @@
   "engines": {
     "node": ">=0.7.0"
   },
-  "dependencies": {
-    "onecolor": "^3.0.4"
-  },
   "devDependencies": {
     "browserify": "^14.3.0",
     "chai": "^3.5.0",

--- a/scripts/test
+++ b/scripts/test
@@ -11,8 +11,12 @@ case $1 in
   # *) browser=$1 ;;
 esac
 
-if [[ $BROWSER_STACK_ENV ]] || [[ $1 == browserstack:* ]]; then
+if [[ $1 == browserstack:* ]]; then
   browser="$1"
+fi
+
+if [ $BROWSER_STACK_ENV ]; then
+  browser="browserstack:chrome"
 fi
 
 if [ ! $browser ]; then

--- a/sources/index.js
+++ b/sources/index.js
@@ -8,7 +8,11 @@ function chaiStyle(chai, utils) {
     const element = flag(this, 'object')
     const style = window.getComputedStyle(element)
     value = value.trim()
-    const propertyValue = style[property] === 'rgba(0, 0, 0, 0)'
+
+    const isNonColors = style[property] === 'rgba(0, 0, 0, 0)' // webkit
+      || style[property] === 'transparent' // firefox
+
+    const propertyValue = isNonColors
       ? ''
       : style[property]
 

--- a/sources/index.js
+++ b/sources/index.js
@@ -12,7 +12,7 @@ function chaiStyle(chai, utils) {
 
     const assertion = value
       ? compareCSSValue(propertyValue, value)
-      : Boolean(propertyValue)
+      : !Boolean(propertyValue) || propertyValue !== 'rgba(0, 0, 0, 0)'
 
     const elementTag = element.tagName.toLowerCase()
 

--- a/sources/index.js
+++ b/sources/index.js
@@ -8,11 +8,13 @@ function chaiStyle(chai, utils) {
     const element = flag(this, 'object')
     const style = window.getComputedStyle(element)
     value = value.trim()
-    const propertyValue = style[property]
+    const propertyValue = style[property] === 'rgba(0, 0, 0, 0)'
+      ? ''
+      : style[property]
 
     const assertion = value
       ? compareCSSValue(propertyValue, value)
-      : !Boolean(propertyValue) || propertyValue !== 'rgba(0, 0, 0, 0)'
+      : Boolean(propertyValue)
 
     const elementTag = element.tagName.toLowerCase()
 

--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -169,7 +169,7 @@ describe('chai-style', () => {
       expect(element).to.have.style('height', '50vh')
     })
 
-    it('should assert in pixels, but defined with vh', () => {
+    it('should assert in pixels, but defined with VH', () => {
       const viewPortHeight = document.documentElement.clientHeight
       const halfViewPortHeight = viewPortHeight / 2
       expect(element).to.have.style('height', `${halfViewPortHeight}px`)
@@ -181,7 +181,7 @@ describe('chai-style', () => {
       expect(element).to.have.style('width', '50vw')
     })
 
-    it('should assert in pixels, but defined with vw', () => {
+    it('should assert in pixels, but defined with VW', () => {
       const viewPortWidth = document.documentElement.clientWidth
       const halfViewPortHeight = viewPortWidth / 2
       expect(element).to.have.style('width', `${halfViewPortHeight}px`)

--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -22,6 +22,7 @@ beforeEach(function createElement() {
   element.style.padding = '0 10px'
   element.style.height = '50vh'
   element.style.width = '50vw'
+  element.style.boxShadow = '0 0 10px red'
 })
 
 describe('chai-style', () => {
@@ -184,6 +185,12 @@ describe('chai-style', () => {
       const viewPortWidth = document.documentElement.clientWidth
       const halfViewPortHeight = viewPortWidth / 2
       expect(element).to.have.style('width', `${halfViewPortHeight}px`)
+    })
+  })
+
+  describe('Different order of values', () => {
+    it('test box-shadow', () => {
+      expect(element).to.have.style('box-shadow', '0 0 10px red')
     })
   })
 })


### PR DESCRIPTION
to fix errors with different order in css, example

```css
// implemented
box-shadow: 0 0 0 red;
```

```css
// computed
box-shadow: rgb(255, 0, 0) 0px 0px 0px;
```

note, the box-shadow accept the following arguments`h-shadow v-shadow blur spread color`. So in the "implemented" css, I dont define spread

now in "computed" css, the browser return in different order, color goes to the first argument, browser convert units, to a pixel, and set the missing arguments (spread) to 0px

this PR try resolve this, creating a "fake" css.

basically, I create a iframe, add a fake element, set the style expected, compute their, and compare with received in element.