### PR TITLE
Adjust spec with VW

### DIFF
--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -182,9 +182,7 @@ describe('chai-style', () => {
     })
 
     it('should assert in pixels, but defined with VW', () => {
-      const viewPortWidth = document.documentElement.clientWidth
-      const halfViewPortHeight = viewPortWidth / 2
-      expect(element).to.have.style('width', `${halfViewPortHeight}px`)
+      expect(element).to.have.style('width', `${window.innerWidth / 2}px`)
     })
   })
 

--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -170,9 +170,7 @@ describe('chai-style', () => {
     })
 
     it('should assert in pixels, but defined with VH', () => {
-      const viewPortHeight = document.documentElement.clientHeight
-      const halfViewPortHeight = viewPortHeight / 2
-      expect(element).to.have.style('height', `${halfViewPortHeight}px`)
+      expect(element).to.have.style('height', `${window.innerHeight / 2}px`)
     })
   })
 


### PR DESCRIPTION
Scroll tool in Mac OS doesn't have size but in windows and linux does.

So, it was necessary change the assertion to innerWidth.