### PR TITLE
Rename-assertions

### DIFF
--- a/sources/index.js
+++ b/sources/index.js
@@ -28,9 +28,10 @@ function chaiStyle(chai, utils) {
     this.assert(assertion, throwMessage, throwMessageNegative, value)
 
     function compareCSSValue(computed, expected) {
+      const propertyHifenCase = property.replace(/[A-Z]/g, (match) => '-' + match.toLowerCase())
       const fake = document.createElement('div')
       fake.style.fontSize = style.fontSize
-      fake.style.setProperty(property, expected, 'important')
+      fake.style.setProperty(propertyHifenCase, expected, 'important')
       const iframe = document.createElement('iframe')
       iframe.style.visibility = 'hidden'
       document.body.appendChild(iframe)
@@ -41,8 +42,6 @@ function chaiStyle(chai, utils) {
       const hasAutoValue = value.includes('auto')
       const reg = new RegExp(value.replace(/auto/g, '(\\d+(.\\d+)?px|auto)'))
 
-      // console.log(`${computed} === ${value}`, computed === value)
-      // console.log('expected', reg.toString(), reg.test(computed))
       return hasAutoValue
         ? reg.test(computed)
         : computed === value

--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -113,10 +113,6 @@ describe('chai-style', () => {
       expect(element).to.have.style('color', 'rgba(255, 0, 0, 1)')
     })
 
-    it('should assert color values using rgba', () => {
-      expect(element).to.have.style('color', 'rgba(255, 0, 0, 1)')
-    })
-
     it('should assert color values using hsl', () => {
       expect(element).to.have.style('color', 'hsl(0, 100%, 50%)')
     })
@@ -184,8 +180,8 @@ describe('chai-style', () => {
     })
   })
 
-  describe('Different order of values', () => {
-    it('test box-shadow', () => {
+  describe('Differents order of pixels values', () => {
+    it('box-shadow test', () => {
       expect(element).to.have.style('box-shadow', '0 0 10px red')
     })
   })

--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -86,6 +86,10 @@ describe('chai-style', () => {
     it('should get value defined in external css', () => {
       expect(element).to.have.style('textTransform', 'uppercase')
     })
+
+    it('should assert with any order of value', () => {
+      expect(element).to.have.style('boxShadow', '#F00 0px 0px 10px 0px')
+    })
   })
 
   describe('colors', () => {
@@ -177,12 +181,6 @@ describe('chai-style', () => {
 
     it('should assert in pixels, but defined with VW', () => {
       expect(element).to.have.style('width', `${window.innerWidth / 2}px`)
-    })
-  })
-
-  describe('Differents order of pixels values', () => {
-    it('box-shadow test', () => {
-      expect(element).to.have.style('box-shadow', '0 0 10px red')
     })
   })
 })

--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -88,6 +88,10 @@ describe('chai-style', () => {
     })
 
     it('should assert with any order of value', () => {
+      expect(element).to.have.style('box-shadow', '#F00 0px 0px 10px 0px')
+    })
+
+    it('should assert with any order of value in camelCase property', () => {
       expect(element).to.have.style('boxShadow', '#F00 0px 0px 10px 0px')
     })
   })


### PR DESCRIPTION
It was excluded one assertion because was duplicated and renamed one assertion.