### PR TITLE
detect all available browsers, on script test, by default

### DIFF
--- a/karma.config.js
+++ b/karma.config.js
@@ -1,6 +1,17 @@
 module.exports = KarmaConfig
 
 function KarmaConfig(config) {
+  const browser = process.argv[5]
+  const browsers = [
+    'Chrome',
+    'Safari',
+    'Firefox',
+    'Nightmare',
+    'browserstack:chrome',
+    'browserstack:safari',
+    'browserstack:firefox',
+  ]
+
   config.set({
     basePath: '',
     port: 9876,
@@ -8,15 +19,7 @@ function KarmaConfig(config) {
     logLevel: config.LOG_ERROR,
     singleRun: true,
 
-    browsers: [
-      'Chrome',
-      'Safari',
-      'Firefox',
-      'Nightmare',
-      'browserstack:chrome',
-      'browserstack:safari',
-      'browserstack:firefox',
-    ],
+    browsers,
 
     customLaunchers: {
       'browserstack:chrome': {
@@ -55,6 +58,7 @@ function KarmaConfig(config) {
     frameworks: [
       'browserify',
       'mocha',
+      'detectBrowsers',
     ],
 
     files: [
@@ -81,6 +85,16 @@ function KarmaConfig(config) {
 
     mochaReporter: {
       output: 'autowatch',
+    },
+
+    detectBrowsers: {
+      enabled: browser === 'all',
+      usePhantomJS: false,
+      postDetection(availableBrowsers) {
+        const runnableBrowsers = availableBrowsers.filter(browser => browsers.indexOf(browser) > -1)
+        console.log(`Testing specs in ${runnableBrowsers.length} browsers (${runnableBrowsers.join(', ')})`)
+        return runnableBrowsers
+      },
     },
   })
 }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "karma-browserify": "^5.1.1",
     "karma-browserstack-launcher": "^1.2.0",
     "karma-chrome-launcher": "^2.1.0",
+    "karma-detect-browsers": "^2.2.5",
     "karma-firefox-launcher": "^1.0.1",
     "karma-mocha": "^1.3.0",
     "karma-mocha-reporter": "^2.2.3",

--- a/scripts/test
+++ b/scripts/test
@@ -7,8 +7,7 @@ case $1 in
   safari) browser="Safari" ;;
   firefox) browser="Firefox" ;;
   nightmare) browser="Nightmare" ;;
-  all) browser="Chrome,Safari,Firefox,Nightmare" ;;
-  *) browser="Nightmare" ;;
+  *) browser="all" ;;
 esac
 
 if [[ $1 == browserstack:* ]]; then


### PR DESCRIPTION
changing script test, following issue https://github.com/darlanmendonca/chai-style/issues/6

now, in development, script test detect all available browsers

```
npm test
```

and if want only specific browsers, continue being

```
npm test chrome
```