### PR TITLE
Improve handling of non-RegExp-safe CSS values

### DIFF
--- a/sources/index.js
+++ b/sources/index.js
@@ -40,7 +40,7 @@ function chaiStyle(chai, utils) {
       const value = fakeStyle[property]
 
       const hasAutoValue = value.includes('auto')
-      const reg = new RegExp(value.replace(/auto/g, '(\\d+(.\\d+)?px|auto)'))
+      const reg = new RegExp(escapeRegExp(value).replace(/auto/g, '(\\d+(.\\d+)?px|auto)'))
 
       return hasAutoValue
         ? reg.test(computed)
@@ -49,3 +49,7 @@ function chaiStyle(chai, utils) {
   })
 }
 
+// https://github.com/benjamingr/RegExp.escape/blob/master/polyfill.js
+function escapeRegExp(value) {
+    return String(value).replace(/[\\^$*+?.()|[\]{}]/g, '\\$&')
+}

--- a/sources/index.spec.js
+++ b/sources/index.spec.js
@@ -41,6 +41,10 @@ describe('chai-style', () => {
     it('should get property defined in external css', () => {
       expect(element).to.have.style('textTransform')
     })
+
+    it('should support asserting non-regex-safe values', () => {
+      expect(element).to.have.style('backgroundImage', 'url("data:image/gif;base64,ABC++DEF==")')
+    })
   })
 
   describe('values', () => {
@@ -195,4 +199,5 @@ function createElement() {
   element.style.height = '50vh'
   element.style.width = '50vw'
   element.style.boxShadow = '0 0 10px red'
+  element.style.backgroundImage = 'url("data:image/gif;base64,ABC++DEF==")'
 }


### PR DESCRIPTION
Added a test and a fix for handling of CSS values that are not safe for RegExp testing.
My use case included a `background-size` rule with a value of `url("[BASE64 image that encoded to ++ somewhere in the string]")`.

My original image string is too verbose for a test, so used a mocked (not-really-working) base64 fixture..

Thanks for the useful matcher!